### PR TITLE
fix user update function

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,3 +67,6 @@ gem 'sprockets', '3.7.2'
 gem 'devise'
 gem "haml-rails"
 
+gem 'devise-i18n'
+gem 'devise-i18n-views'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,9 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.9.0)
+      devise (>= 4.7.1)
+    devise-i18n-views (0.3.7)
     erubi (1.9.0)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -249,6 +252,8 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   compass-rails (= 3.1.0)
   devise
+  devise-i18n
+  devise-i18n-views
   haml-rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
 
     def configure_permitted_parameters
       devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :incomes, :fixedcosts, :savings])
+      devise_parameter_sanitizer.permit(:account_update, keys: [:name, :incomes, :fixedcosts, :savings])
     end
     
 

--- a/app/views/users/registrations/edit.html.haml
+++ b/app/views/users/registrations/edit.html.haml
@@ -11,38 +11,38 @@
       Currently waiting confirmation for: #{resource.unconfirmed_email}
   .field
     = f.label :password
-    %i (leave blank if you don't want to change it)
+    %i （変更する場合は入力して下さい。）
     %br/
     = f.password_field :password, autocomplete: "new-password"
     - if @minimum_password_length
       %br/
       %em
         = @minimum_password_length
-        characters minimum
+        文字以上
   .field
     = f.label :password_confirmation
     %br/
     = f.password_field :password_confirmation, autocomplete: "new-password"
   .field
     = f.label :current_password
-    %i (we need your current password to confirm your changes)
+    %i （変更を確認するには現在のパスワードが必要です。）
     %br/
     = f.password_field :current_password, autocomplete: "current-password"
   .field
-    = f.label :incomes
+    = f.label :年収
     %br/
     = f.number_field :incomes
     .field
-    = f.label :fixedcosts
+    = f.label :１年間の固定費（生活費等）
     %br/
     = f.number_field :fixedcosts
   .field
-    = f.label :savings
+    = f.label :１年間の目標貯蓄額
     %br/
     = f.number_field :savings
   .actions
     = f.submit "Update"
-%h3 Cancel my account
+%h3 アカウントをキャンセルしても
 %p
-  Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
+  よろしいですか? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
 = link_to "Back", :back

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -2,7 +2,7 @@
 = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
   = render "devise/shared/error_messages", resource: resource
   .field
-    = f.label :name
+    = f.label :お名前
     %br/
     = f.text_field :name, autofocus: true
   .field
@@ -21,15 +21,15 @@
     %br/
     = f.password_field :password_confirmation, autocomplete: "new-password"
   .field
-    = f.label :incomes
+    = f.label :年収
     %br/
     = f.number_field :incomes
   .field
-    = f.label :fixedcosts
+    = f.label :１年間の固定費（生活費等）
     %br/
     = f.number_field :fixedcosts
   .field
-    = f.label :savings
+    = f.label :１年間の目標貯蓄額
     %br/
     = f.number_field :savings
   .actions

--- a/app/views/users/shared/_links.html.haml
+++ b/app/views/users/shared/_links.html.haml
@@ -2,10 +2,10 @@
   = link_to "Log in", new_session_path(resource_name)
   %br/
 - if devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to "Sign up", new_registration_path(resource_name)
+  = link_to "新しくアカウントを登録", new_registration_path(resource_name)
   %br/
 - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-  = link_to "Forgot your password?", new_password_path(resource_name)
+  = link_to "パスワードをお忘れですか？", new_password_path(resource_name)
   %br/
 - if devise_mapping.confirmable? && controller_name != 'confirmations'
   = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ module MoneyWishList
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-
+    config.i18n.default_locale = :ja
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -1,0 +1,67 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        current_password: "現在のパスワード"
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "確認用パスワード"
+        remember_me: "ログインを記憶"
+    models:
+      user: "ユーザ"
+  devise:
+    confirmations:
+      new:
+        resend_confirmation_instructions: "アカウント確認メール再送"
+    mailer:
+      confirmation_instructions:
+        action: "アカウント確認"
+        greeting: "ようこそ、%{recipient}さん!"
+        instruction: "次のリンクでメールアドレスの確認が完了します:"
+      reset_password_instructions:
+        action: "パスワード変更"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "誰かがパスワードの再設定を希望しました。次のリンクでパスワードの再設定が出来ます。"
+        instruction_2: "あなたが希望したのではないのなら、このメールは無視してください。"
+        instruction_3: "上のリンクにアクセスして新しいパスワードを設定するまで、パスワードは変更されません。"
+      unlock_instructions:
+        action: "アカウントのロック解除"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "アカウントのロックを解除するには下のリンクをクリックしてください。"
+        message: "ログイン失敗が繰り返されたため、アカウントはロックされています。"
+    passwords:
+      edit:
+        change_my_password: "パスワードを変更する"
+        change_your_password: "パスワードを変更"
+        confirm_new_password: "確認用新しいパスワード"
+        new_password: "新しいパスワード"
+      new:
+        forgot_your_password: "パスワードを忘れましたか?"
+        send_me_reset_password_instructions: "パスワードの再設定方法を送信する"
+    registrations:
+      edit:
+        are_you_sure: "本当に良いですか?"
+        cancel_my_account: "アカウント削除"
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: "空欄のままなら変更しません"
+        title: "%{resource}編集"
+        unhappy: "気に入りません"
+        update: "更新"
+        we_need_your_current_password_to_confirm_your_changes: "変更を反映するには現在のパスワードを入力してください"
+      new:
+        sign_up: "アカウント登録"
+    sessions:
+      new:
+        sign_in: "ログイン"
+    shared:
+      links:
+        back: "戻る"
+        didn_t_receive_confirmation_instructions: "アカウント確認のメールを受け取っていませんか?"
+        didn_t_receive_unlock_instructions: "アカウントの凍結解除方法のメールを受け取っていませんか?"
+        forgot_your_password: "パスワードを忘れましたか?"
+        sign_in: "ログイン"
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: "アカウント登録"
+    unlocks:
+      new:
+        resend_unlock_instructions: "アカウントの凍結解除方法を再送する"


### PR DESCRIPTION
# What
ユーザーのアカウント変更機能を修正。
plant登録画面のサイドバーからユーザー変更画面へ遷移し、変更後plan登録画面へ戻りビューに変更反映。
devise日本語対応済。
ユーザー関係のビューは未済。

# Why
devise導入時に追加したユーザーのカラムの変更ができなかったため。