### PR TITLE
add view user edit page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,4 +3,4 @@
 @import "./signup";
 @import "./wishes";
 @import "./records";
-
+@import "./edit";

--- a/app/assets/stylesheets/edit.scss
+++ b/app/assets/stylesheets/edit.scss
@@ -1,0 +1,46 @@
+.create-container__edit{
+  font-size: 1.5rem;
+  margin-bottom: 10px;
+  letter-spacing: 0.1em; 
+}
+
+#user_current_password {
+  width: 400px;
+  height: 40px;
+}
+
+.update-btn {
+  -webkit-appearance: none;
+  width: 100px;
+  height: 40px;
+  margin-top: 20px;
+  margin-left: 50px;
+  color: rgb(111, 111, 197);
+  background-color: #e6f2f5;
+  cursor: pointer;
+  border-radius: 5px;
+}
+.action {
+  display: flex;
+}
+.back {
+  color: rgb(111, 111, 197);
+  font-size: 1.2rem;
+  margin-top: 20px;
+  margin-left: 70px;
+  text-decoration: none;
+}
+.cancel {
+  margin-left: 200px;
+  color: rgb(111, 111, 197);
+}
+.delete-btn {
+  -webkit-appearance: none;
+  width: 100px;
+  height: 30px;
+  color: rgb(111, 111, 197);
+  background-color: #e6f2f5;
+  margin-left: 50px;
+  cursor: pointer;
+  border-radius: 5px;
+}

--- a/app/assets/stylesheets/login.scss
+++ b/app/assets/stylesheets/login.scss
@@ -58,28 +58,28 @@ h2.form-container__login{
 .form-container__login--email{
   padding-bottom: 30px;
 }
-// .form-container__login--button{
-  // width: 400px;
-  // height: 40px;
-  // margin-top: 10px;
-// }
-.login-btn{
-  display:block;
+.login-btn {
+  -webkit-appearance: none;
   width: 200px;
   height: 40px;
-  margin: 10px 0 10px 100px;
+  margin-top: 20px;
+  margin-left: 80px;
+  color: rgb(111, 111, 197);
+  background-color: #e6f2f5;
+  cursor: pointer;
+  border-radius: 5px;
 }
 
 .new-btn{
   display: block;
   text-decoration: none;
-  margin: 50px 0 0 100px;
+  margin: 30px 0 0 120px;
   color: rgb(111, 111, 197);
 }
 .forget-btn{
   display: block;
   text-decoration: none;
-  margin: 50px 0 0 100px;
+  margin: 30px 0 0 120px;
   color:  rgb(111, 111, 197);
 }
 

--- a/app/assets/stylesheets/signup.scss
+++ b/app/assets/stylesheets/signup.scss
@@ -50,9 +50,7 @@ h3.guide-container__message{
   font-size: 2rem;
   margin-bottom: 10px;
   letter-spacing: 0.1em; 
-  
   }
-  
 } 
 
 #user_name, #user_incomes, #user_fixedcosts, #user_savings{
@@ -65,10 +63,15 @@ h3.guide-container__message{
 }
 
 .signup-btn{
-  display:block;
-  width: 200px;
+  -webkit-appearance: none;
+  width: 100px;
   height: 40px;
-  margin: 10px 0 10px 100px;
+  margin-top: 20px;
+  margin-left: 50px;
+  color:rgb(111, 111, 197);
+  background-color: #e6f2f5;
+  cursor: pointer;
+  border-radius: 5px; 
 }
 
 .login-btn{

--- a/app/views/users/registrations/edit.html.haml
+++ b/app/views/users/registrations/edit.html.haml
@@ -1,48 +1,70 @@
-%h2
-  Edit #{resource_name.to_s.humanize}
-= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
+.guide-container
+  %h1.guide-container__title Money Wish List
+  %h2.guide-container__subtitle 〜人生１００年時代を生き抜く〜
+  %h3.guide-container__message
+    1年間でどれくらい大きな額のお買い物をしていますか？ 
     %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    %div
-      Currently waiting confirmation for: #{resource.unconfirmed_email}
-  .field
-    = f.label :password
-    %i （変更する場合は入力して下さい。）
     %br/
-    = f.password_field :password, autocomplete: "new-password"
-    - if @minimum_password_length
+    .list Record List
+    %br/
+    大きな額のお買い物をしたら記録しましょう。
+    %br/
+    １年間であといくら使えるかわかります。
+    %br/
+    %br/
+    .list Wish List
+    %br/
+    ほしい大きなお買い物をリスト化しておきましょう。
+    %br/
+    買う前に予定を立てて、本当に必要なものか考えることができます。
+
+
+
+.create-container
+  %h2.create-container__edit アカウントを変更 
+  -# #{resource_name.to_s.humanize}
+  = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+    = render "devise/shared/error_messages", resource: resource
+    .create-container__edit--email
+      = f.label :email
       %br/
-      %em
-        = @minimum_password_length
-        文字以上
-  .field
-    = f.label :password_confirmation
-    %br/
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .field
-    = f.label :current_password
-    %i （変更を確認するには現在のパスワードが必要です。）
-    %br/
-    = f.password_field :current_password, autocomplete: "current-password"
-  .field
-    = f.label :年収
-    %br/
-    = f.number_field :incomes
-    .field
-    = f.label :１年間の固定費（生活費等）
-    %br/
-    = f.number_field :fixedcosts
-  .field
-    = f.label :１年間の目標貯蓄額
-    %br/
-    = f.number_field :savings
-  .actions
-    = f.submit "Update"
-%h3 アカウントをキャンセルしても
-%p
-  よろしいですか? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
-= link_to "Back", :back
+      = f.email_field :email, autofocus: true, autocomplete: "email"
+    - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+      %div
+        Currently waiting confirmation for: #{resource.unconfirmed_email}
+    .create-container__edit--passward
+      = f.label :password
+      %i （変更する場合は入力して下さい。）
+      %br/
+      = f.password_field :password, autocomplete: "new-password"
+      - if @minimum_password_length
+        %br/
+        %em
+          = @minimum_password_length
+          文字以上
+    .create-container__edit--passward
+      = f.label :password_confirmation
+      %br/
+      = f.password_field :password_confirmation, autocomplete: "new-password"
+    .create-container__edit--passward
+      = f.label :current_password
+      %i （変更を確認するには現在のパスワードが必要です。）
+      %br/
+      = f.password_field :current_password, autocomplete: "current-password"
+    .create-container__edit--incomes
+      = f.label :年収
+      %br/
+      = f.number_field :incomes
+    .create-container__edit--fixedcosts
+      = f.label :１年間の固定費（生活費等）
+      %br/
+      = f.number_field :fixedcosts
+    .create-container__signup--savings
+      = f.label :１年間の目標貯蓄額
+      %br/
+      = f.number_field :savings
+    = f.submit "Update", class:'update-btn'
+  .action
+    = link_to "Back", :back, class:'back'
+    %h3.cancel 退会してもよろしいですか? #{button_to "退会", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class:'delete-btn'}
+    

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -54,5 +54,6 @@
       = f.label :１年間の目標貯蓄額
       %br/
       = f.number_field :savings
+    -# .action
     = f.submit "Sign up", class: 'signup-btn'
-  = render "users/shared/links"
+    = render "users/shared/links"

--- a/app/views/users/shared/_links.html.haml
+++ b/app/views/users/shared/_links.html.haml
@@ -1,5 +1,5 @@
 - if controller_name != 'sessions'
-  = link_to "アカウントをお持ちの方", new_session_path(resource_name) , class: 'login-btn'
+  = link_to "アカウントをお持ちの方", new_session_path(resource_name) , class: 'back'
   %br/
 - if devise_mapping.registerable? && controller_name != 'registrations'
   = link_to "新しくアカウントを登録", new_registration_path(resource_name) , class: 'new-btn'


### PR DESCRIPTION
# What
ユーザーの編集画面を実装。
ユーザーのログイン、新規登録のビューも修正済み。
以下修正未済
- ログイン、新規登録、編集→フラッシュメーッセージ、エラーメッセージでビューが下がる。
- 新規登録、編集→金額入力欄

# Why
ユーザーの編集をできるようにするため。